### PR TITLE
Create multiple vms on gcp

### DIFF
--- a/compute_attached_disk.tf
+++ b/compute_attached_disk.tf
@@ -1,4 +1,5 @@
 resource "google_compute_attached_disk" "data_disk_attach" {
-  disk = google_compute_disk.test_disk.id
-  instance = google_compute_instance.amb-prod.id
+  count = var.instance_count
+  disk = google_compute_disk.test_disk[count.index].id
+  instance = google_compute_instance.amb-prod[count.index].id
 }

--- a/compute_disk.tf
+++ b/compute_disk.tf
@@ -1,5 +1,6 @@
 resource "google_compute_disk" "test_disk" {
-  name = "terraform-disk"
+  count = var.instance_count
+  name = "terraform-disk-${count.index}"
   type = "pd-standard"
   zone = var.zone
   size = var.size

--- a/compute_instance.tf
+++ b/compute_instance.tf
@@ -1,9 +1,11 @@
 resource "google_compute_instance" "amb-prod" {
-  name =  "terraform-instance"
+  count = var.instance_count
+  name = "terraform-instance-${count.index}"
   machine_type = var.machine_type
   zone = var.zone
   allow_stopping_for_update = true
   metadata_startup_script = file(var.script_file)
+
   boot_disk {
     initialize_params {
       image = var.os_image
@@ -15,12 +17,10 @@ resource "google_compute_instance" "amb-prod" {
     access_config {
     }
   }
-
   provisioner "file" {
     source = var.script_file
     destination = "/tmp/script.sh"
   }
-
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/script.sh",
@@ -35,5 +35,4 @@ resource "google_compute_instance" "amb-prod" {
     private_key = file(var.gce_ssh_private_key_file)
     timeout = "4m"
   }
- 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,10 +34,17 @@ variable "user" {
 }
 
 variable "size" {
+  description = "value of the disk size in GB"
   default = 20
 }
 
 variable "script_file" {
   default = "scripts/script.sh"
   
+}
+
+variable "instance_count" {
+  description = "Number of instances to create"
+  type = number
+  default = 3
 }


### PR DESCRIPTION
Adiciono função de criar varias maquinas ao mesmo tempo,
lembrar de adicionar os contadores para os dispositivos como o disco, e as instancias.
